### PR TITLE
[Onetimesecret] fix typo

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -286,7 +286,7 @@ helpers do
       Pony.mail({
         :from        => $appconfig['smtp_from'],
         :to          => to,
-        :subject     => 'Secret shared via Onetimescret',
+        :subject     => 'Secret shared via Onetimesecret',
         :body        => text_body,
         :html_body   => html_body,
         :via         => :smtp,


### PR DESCRIPTION
USD 9841964. There is a typo in the Onetimesecret mail subject.
![Screenshot_2025-01-09_105357](https://github.com/user-attachments/assets/648ca536-6deb-426b-a366-3e9f14bd52bc)
